### PR TITLE
feat: Added a Makefile to simplify the building and publishing process.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	dotnet publish -c Release -r osx-arm64 --self-contained true


### PR DESCRIPTION
This pull request introduces a new `all` target in the `Makefile` to streamline the build process for macOS on ARM64 architecture.

Build process improvement:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R2): Added an `all` target that publishes the project using the `dotnet` CLI with the `Release` configuration, targeting `osx-arm64` and enabling self-contained deployment.