### PR TITLE
refactor: Refactored the solution and project #2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ agentDir = ${HOME}/Library/LaunchAgents
 agentFile = ${agentDir}/com.samurai-os.hosam.plist
 
 publish:
-	dotnet publish -c Release -r osx-arm64 --self-contained true -p:PublishDir=${appPath} -p:PublishSingleFile=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true
+	dotnet publish -c Release --self-contained true -p:PublishDir=${appPath} -p:PublishSingleFile=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true
 	chmod +x ${appPath}/hosam
 	cp ./com.samurai-os.hosam.plist ${agentDir}/
 

--- a/README.md
+++ b/README.md
@@ -3,36 +3,45 @@
 A cross-platform **(if you need)** .NET host application for keyboard event handling and automation, leveraging SharpHook and Serilog for logging and event management.
 
 ## Features
+
 - Global keyboard event capture
 - Reactive event handling
 - Configurable logging (console and file)
 - Extensible architecture for automation tasks
 
 ## Requirements
+
 - .NET 9.0 SDK or later
 - MacOS
 
 ## Installation
+
 1. Clone the repository:
+
    ```sh
-   git clone https://github.com/yourusername/hosam.git
+   git clone https://github.com/samurai-os/hosam.git
    cd hosam
    ```
 
 ## Build
+
 To build the project:
+
 ```sh
 make
 ```
 
 ## Usage
+
 Run the host application:
+
 ```sh
-cd HoSam.Host
-dotnet run
+make run
 ```
 
 ## Project Structure
-- `HoSam.Host/` — Main application source code
+
+- `hosam/` — Main application source code
 - `KeyPressHandler.cs` — Keyboard event handling logic
 - `Program.cs` — Application entry point
+- `LogConfiguration.cs` - Serilog configuration for logging


### PR DESCRIPTION
This pull request introduces updates to the `Makefile` and `README.md` to simplify the build process and improve documentation clarity. The most significant changes include modifying the `dotnet publish` command in the `Makefile` and updating the repository URL, build instructions, and project structure in the `README.md`.

### Build process updates:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-R14): Removed the `-r osx-arm64` runtime specification from the `dotnet publish` command, making the build process more flexible for different platforms.

### Documentation improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R47): Updated the repository URL to `https://github.com/samurai-os/hosam.git` for accuracy.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R47): Replaced `dotnet run` with `make run` in the usage instructions to align with the updated build process.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R47): Adjusted the project structure section to reflect the correct directory name (`hosam/`) and added a description for `LogConfiguration.cs`.